### PR TITLE
Attach source codes when deploying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,6 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
-                        <phase>none</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>


### PR DESCRIPTION
As an SDK library, attaching `-sources.jar` can be more convenient for users to read the source codes in IDE, without decompiling the bytecoce