### PR TITLE
Add single write API and refactor projection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,12 @@
             <version>${javax.annotation-api.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.21.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/StreamQuery.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/StreamQuery.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.banyandb.v1.client;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -63,9 +64,9 @@ public class StreamQuery {
      */
     private OrderBy orderBy;
     /**
-     * Whether to fetch data_binary for the query
+     * Whether to fetch unindexed fields from the "data" tag family for the query
      */
-    private boolean dataBinary;
+    private List<String> dataProjections;
 
     public StreamQuery(final String name, final TimestampRange timestampRange, final List<String> projections) {
         this.name = name;
@@ -74,7 +75,8 @@ public class StreamQuery {
         this.conditions = new ArrayList<>(10);
         this.offset = 0;
         this.limit = 20;
-        this.dataBinary = false;
+        // by default, we don't need projection for data tag family
+        this.dataProjections = Collections.emptyList();
     }
 
     public StreamQuery(final String name, final List<String> projections) {
@@ -110,10 +112,10 @@ public class StreamQuery {
                         .setName("searchable")
                         .addAllTags(this.projections)
                         .build());
-        if (this.dataBinary) {
+        if (!this.dataProjections.isEmpty()) {
             projectionBuilder.addTagFamilies(Banyandb.Projection.TagFamily.newBuilder()
                     .setName("data")
-                    .addTags("data_binary")
+                    .addAllTags(this.dataProjections)
                     .build());
         }
         builder.setProjection(projectionBuilder);

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/Tag.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/Tag.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.banyandb.v1.client;
 
 import java.util.List;
 
+import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.skywalking.banyandb.v1.Banyandb;
@@ -112,6 +113,20 @@ public abstract class Tag<T> {
     }
 
     /**
+     * The value of a byte array(ByteString) type field.
+     */
+    public static class BinaryField extends Tag<ByteString> implements SerializableTag<Banyandb.TagValue> {
+        public BinaryField(ByteString byteString) {
+            super(byteString);
+        }
+
+        @Override
+        public Banyandb.TagValue toTag() {
+            return Banyandb.TagValue.newBuilder().setBinaryData(value).build();
+        }
+    }
+
+    /**
      * Construct a string field
      *
      * @param val payload
@@ -139,6 +154,16 @@ public abstract class Tag<T> {
      */
     public static SerializableTag<Banyandb.TagValue> stringArrayField(List<String> val) {
         return new StringArrayField(val);
+    }
+
+    /**
+     * Construct a byte array field.
+     *
+     * @param bytes binary data
+     * @return Anonymous field with binary payload
+     */
+    public static SerializableTag<Banyandb.TagValue> binaryField(byte[] bytes) {
+        return new BinaryField(ByteString.copyFrom(bytes));
     }
 
     /**

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/TagAndValue.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/TagAndValue.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.banyandb.v1.client;
 
 import java.util.List;
 
+import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import org.apache.skywalking.banyandb.v1.Banyandb;
 
@@ -68,6 +69,8 @@ public abstract class TagAndValue<T> extends Tag<T> {
                 return new LongArrayTagPair(tagFamilyName, tag.getKey(), tag.getValue().getIntArray().getValueList());
             case STR_ARRAY:
                 return new StringArrayTagPair(tagFamilyName, tag.getKey(), tag.getValue().getStrArray().getValueList());
+            case BINARY_DATA:
+                return new BinaryTagPair(tagFamilyName, tag.getKey(), tag.getValue().getBinaryData());
             case NULL:
                 return new NullTagPair(tagFamilyName, tag.getKey());
             default:
@@ -96,6 +99,12 @@ public abstract class TagAndValue<T> extends Tag<T> {
     public static class LongArrayTagPair extends TagAndValue<List<Long>> {
         LongArrayTagPair(final String tagFamilyName, final String tagName, final List<Long> value) {
             super(tagFamilyName, tagName, value);
+        }
+    }
+
+    public static class BinaryTagPair extends TagAndValue<ByteString> {
+        public BinaryTagPair(String tagFamilyName, String fieldName, ByteString byteString) {
+            super(tagFamilyName, fieldName, byteString);
         }
     }
 

--- a/src/test/java/org/apache/skywalking/banyandb/v1/client/BanyanDBClientWriteTest.java
+++ b/src/test/java/org/apache/skywalking/banyandb/v1/client/BanyanDBClientWriteTest.java
@@ -120,22 +120,22 @@ public class BanyanDBClientWriteTest {
 
         StreamWrite streamWrite = StreamWrite.builder()
                 .elementId(segmentId)
-                .binary(byteData)
+                .dataTag(Tag.binaryField(byteData))
                 .timestamp(now.toEpochMilli())
                 .name("sw")
-                .tag(Tag.stringField(traceId)) // 0
-                .tag(Tag.stringField(serviceId))
-                .tag(Tag.stringField(serviceInstanceId))
-                .tag(Tag.stringField(endpointId))
-                .tag(Tag.longField(latency)) // 4
-                .tag(Tag.longField(state))
-                .tag(Tag.stringField(httpStatusCode))
-                .tag(Tag.nullField()) // 7
-                .tag(Tag.stringField(dbType))
-                .tag(Tag.stringField(dbInstance))
-                .tag(Tag.stringField(broker))
-                .tag(Tag.stringField(topic))
-                .tag(Tag.stringField(queue)) // 12
+                .searchableTag(Tag.stringField(traceId)) // 0
+                .searchableTag(Tag.stringField(serviceId))
+                .searchableTag(Tag.stringField(serviceInstanceId))
+                .searchableTag(Tag.stringField(endpointId))
+                .searchableTag(Tag.longField(latency)) // 4
+                .searchableTag(Tag.longField(state))
+                .searchableTag(Tag.stringField(httpStatusCode))
+                .searchableTag(Tag.nullField()) // 7
+                .searchableTag(Tag.stringField(dbType))
+                .searchableTag(Tag.stringField(dbInstance))
+                .searchableTag(Tag.stringField(broker))
+                .searchableTag(Tag.stringField(topic))
+                .searchableTag(Tag.stringField(queue)) // 12
                 .build();
 
         streamBulkWriteProcessor.add(streamWrite);

--- a/src/test/java/org/apache/skywalking/banyandb/v1/client/BanyanDBClientWriteTest.java
+++ b/src/test/java/org/apache/skywalking/banyandb/v1/client/BanyanDBClientWriteTest.java
@@ -153,4 +153,87 @@ public class BanyanDBClientWriteTest {
             Assert.fail();
         }
     }
+
+    @Test
+    public void performSingleWrite() throws Exception {
+        final CountDownLatch allRequestsDelivered = new CountDownLatch(1);
+        final List<BanyandbStream.WriteRequest> writeRequestDelivered = new ArrayList<>();
+
+        // implement the fake service
+        final StreamServiceGrpc.StreamServiceImplBase serviceImpl =
+                new StreamServiceGrpc.StreamServiceImplBase() {
+                    @Override
+                    public StreamObserver<BanyandbStream.WriteRequest> write(StreamObserver<BanyandbStream.WriteResponse> responseObserver) {
+                        return new StreamObserver<BanyandbStream.WriteRequest>() {
+                            @Override
+                            public void onNext(BanyandbStream.WriteRequest value) {
+                                writeRequestDelivered.add(value);
+                                responseObserver.onNext(BanyandbStream.WriteResponse.newBuilder().build());
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                responseObserver.onCompleted();
+                                allRequestsDelivered.countDown();
+                            }
+                        };
+                    }
+                };
+        serviceRegistry.addService(serviceImpl);
+
+        String segmentId = "1231.dfd.123123ssf";
+        String traceId = "trace_id-xxfff.111323";
+        String serviceId = "webapp_id";
+        String serviceInstanceId = "10.0.0.1_id";
+        String endpointId = "home_id";
+        int latency = 200;
+        int state = 1;
+        Instant now = Instant.now();
+        byte[] byteData = new byte[]{14};
+        String broker = "172.16.10.129:9092";
+        String topic = "topic_1";
+        String queue = "queue_2";
+        String httpStatusCode = "200";
+        String dbType = "SQL";
+        String dbInstance = "127.0.0.1:3306";
+
+        StreamWrite streamWrite = StreamWrite.builder()
+                .elementId(segmentId)
+                .dataTag(Tag.binaryField(byteData))
+                .timestamp(now.toEpochMilli())
+                .name("sw")
+                .searchableTag(Tag.stringField(traceId)) // 0
+                .searchableTag(Tag.stringField(serviceId))
+                .searchableTag(Tag.stringField(serviceInstanceId))
+                .searchableTag(Tag.stringField(endpointId))
+                .searchableTag(Tag.longField(latency)) // 4
+                .searchableTag(Tag.longField(state))
+                .searchableTag(Tag.stringField(httpStatusCode))
+                .searchableTag(Tag.nullField()) // 7
+                .searchableTag(Tag.stringField(dbType))
+                .searchableTag(Tag.stringField(dbInstance))
+                .searchableTag(Tag.stringField(broker))
+                .searchableTag(Tag.stringField(topic))
+                .searchableTag(Tag.stringField(queue)) // 12
+                .build();
+
+        client.write(streamWrite);
+
+        if (allRequestsDelivered.await(5, TimeUnit.SECONDS)) {
+            Assert.assertEquals(1, writeRequestDelivered.size());
+            final BanyandbStream.WriteRequest request = writeRequestDelivered.get(0);
+            Assert.assertArrayEquals(byteData, request.getElement().getTagFamilies(0).getTags(0).getBinaryData().toByteArray());
+            Assert.assertEquals(13, request.getElement().getTagFamilies(1).getTagsCount());
+            Assert.assertEquals(traceId, request.getElement().getTagFamilies(1).getTags(0).getStr().getValue());
+            Assert.assertEquals(latency, request.getElement().getTagFamilies(1).getTags(4).getInt().getValue());
+            Assert.assertEquals(request.getElement().getTagFamilies(1).getTags(7).getNull(), NullValue.NULL_VALUE);
+            Assert.assertEquals(queue, request.getElement().getTagFamilies(1).getTags(12).getStr().getValue());
+        } else {
+            Assert.fail();
+        }
+    }
 }


### PR DESCRIPTION
During the work of a new round of OAP integration, I found the limitation of the current implementation.

1. Add single write API for some entities like `UITemplate`
2. Refactor to allow multiple un-indexed fields

Since tag family is already fixed. I just rename the methods with explicit `searchable` and `data`, e.g. `searchableTag` and `dataTag` which means indexed fields and un-indexed ones respectively based on our current convention.

I'm not pretty sure whether we should introduce some more general APIs.

@hanahmily 