### PR TITLE
Support timestamp lazy initialization for StreamWrite.

### DIFF
--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/AbstractWrite.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/AbstractWrite.java
@@ -19,16 +19,14 @@
 package org.apache.skywalking.banyandb.v1.client;
 
 import com.google.protobuf.Timestamp;
+import java.util.Optional;
 import lombok.Getter;
-import lombok.Setter;
 import org.apache.skywalking.banyandb.common.v1.BanyandbCommon;
 import org.apache.skywalking.banyandb.model.v1.BanyandbModel;
 import org.apache.skywalking.banyandb.v1.client.grpc.exception.BanyanDBException;
 import org.apache.skywalking.banyandb.v1.client.grpc.exception.InvalidReferenceException;
 import org.apache.skywalking.banyandb.v1.client.metadata.MetadataCache;
 import org.apache.skywalking.banyandb.v1.client.metadata.Serializable;
-
-import java.util.Optional;
 
 public abstract class AbstractWrite<P extends com.google.protobuf.GeneratedMessageV3> {
     /**

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/AbstractWrite.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/AbstractWrite.java
@@ -45,7 +45,6 @@ public abstract class AbstractWrite<P extends com.google.protobuf.GeneratedMessa
      * Timestamp represents the time of current stream
      * in the timeunit of milliseconds.
      */
-    @Setter
     @Getter
     protected long timestamp;
 

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/StreamWrite.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/StreamWrite.java
@@ -19,16 +19,14 @@
 package org.apache.skywalking.banyandb.v1.client;
 
 import com.google.protobuf.Timestamp;
-
+import java.util.Deque;
+import java.util.LinkedList;
 import lombok.Getter;
 import org.apache.skywalking.banyandb.common.v1.BanyandbCommon;
 import org.apache.skywalking.banyandb.model.v1.BanyandbModel;
 import org.apache.skywalking.banyandb.stream.v1.BanyandbStream;
 import org.apache.skywalking.banyandb.v1.client.grpc.exception.BanyanDBException;
 import org.apache.skywalking.banyandb.v1.client.metadata.Serializable;
-
-import java.util.Deque;
-import java.util.LinkedList;
 
 /**
  * StreamWrite represents a write operation, including necessary fields, for {@link
@@ -57,6 +55,10 @@ public class StreamWrite extends AbstractWrite<BanyandbStream.WriteRequest> {
     @Override
     public StreamWrite tag(String tagName, Serializable<BanyandbModel.TagValue> tagValue) throws BanyanDBException {
         return (StreamWrite) super.tag(tagName, tagValue);
+    }
+
+    public void setTimestamp(long timestamp) {
+        super.timestamp = timestamp;
     }
 
     /**

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/StreamWrite.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/StreamWrite.java
@@ -46,6 +46,14 @@ public class StreamWrite extends AbstractWrite<BanyandbStream.WriteRequest> {
         this.elementId = elementId;
     }
 
+    /**
+     * Create a StreamWrite without initial timestamp.
+     */
+    public StreamWrite(final String group, final String name, final String elementId) {
+        super(group, name);
+        this.elementId = elementId;
+    }
+
     @Override
     public StreamWrite tag(String tagName, Serializable<BanyandbModel.TagValue> tagValue) throws BanyanDBException {
         return (StreamWrite) super.tag(tagName, tagValue);


### PR DESCRIPTION
According to https://github.com/apache/skywalking/issues/10008 discussion, we noticed the current timestamp of stream write is from the time bucket, which is not precise enough(only the second level).

So, I asked @wankai123 to add a BanyanDB annotation to indicate which field of the real timestamp should be used for BanyanDB server to improve the precision. If we don't expose this lazy set, then we can't leverage the converter to read the timestamp field, but have to use reflection. I think this would be better.

This is not exposed to measure write, as AFAIK the measure write is correct to use the time bucket for overriding the previous value in the same time bucket.