### PR TITLE
Tweak Group builders for property operations

### DIFF
--- a/src/test/java/org/apache/skywalking/banyandb/v1/client/BanyanDBClientTestCI.java
+++ b/src/test/java/org/apache/skywalking/banyandb/v1/client/BanyanDBClientTestCI.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 public class BanyanDBClientTestCI {
     private static final String REGISTRY = "ghcr.io";
     private static final String IMAGE_NAME = "apache/skywalking-banyandb";
-    private static final String TAG = "1c19243df23f8350ea5c1542fd914c49e8698960";
+    private static final String TAG = "adbd3e87df7f84e5d1904fcf40476d2e81842058";
 
     private static final String IMAGE = REGISTRY + "/" + IMAGE_NAME + ":" + TAG;
 

--- a/src/test/java/org/apache/skywalking/banyandb/v1/client/ITBanyanDBPropertyTests.java
+++ b/src/test/java/org/apache/skywalking/banyandb/v1/client/ITBanyanDBPropertyTests.java
@@ -20,9 +20,7 @@ package org.apache.skywalking.banyandb.v1.client;
 
 import io.grpc.Status;
 import org.apache.skywalking.banyandb.v1.client.grpc.exception.BanyanDBException;
-import org.apache.skywalking.banyandb.v1.client.metadata.Catalog;
 import org.apache.skywalking.banyandb.v1.client.metadata.Group;
-import org.apache.skywalking.banyandb.v1.client.metadata.IntervalRule;
 import org.apache.skywalking.banyandb.v1.client.metadata.Property;
 import org.junit.After;
 import org.junit.Assert;
@@ -38,11 +36,7 @@ public class ITBanyanDBPropertyTests extends BanyanDBClientTestCI {
     @Before
     public void setUp() throws IOException, BanyanDBException, InterruptedException {
         super.setUpConnection();
-        Group expectedGroup = this.client.define(
-                Group.create("default", Catalog.STREAM, 2, IntervalRule.create(IntervalRule.Unit.HOUR, 4),
-                        IntervalRule.create(IntervalRule.Unit.DAY, 1),
-                        IntervalRule.create(IntervalRule.Unit.DAY, 7))
-        );
+        Group expectedGroup = this.client.define(Group.create("default"));
         Assert.assertNotNull(expectedGroup);
     }
 


### PR DESCRIPTION
This PR is related to https://github.com/apache/skywalking/issues/10413.

The client validated the nullable fields of a `Group`. In this commit, I removed those checkers, adding new `create` functions to build groups for storing properties.

I also update IT's banyandb sha to verify the changes on v0.3.1.