### PR TITLE
Add multi-ID and multi-tag filters to property list operation

### DIFF
--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/BanyanDBClient.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/BanyanDBClient.java
@@ -361,8 +361,22 @@ public class BanyanDBClient implements Closeable {
      * @return all properties belonging to the group and the name
      */
     public List<Property> findProperties(String group, String name) throws BanyanDBException {
+        return findProperties(group, name, null, null);
+
+    }
+
+    /**
+     * List Properties
+     *
+     * @param group group of the metadata
+     * @param name  name of the metadata
+     * @param ids   identities of the properties
+     * @param tags  tags to be returned
+     * @return all properties belonging to the group and the name
+     */
+    public List<Property> findProperties(String group, String name, List<String> ids, List<String> tags) throws BanyanDBException {
         PropertyStore store = new PropertyStore(checkNotNull(this.channel));
-        return store.list(group, name);
+        return store.list(group, name, ids, tags);
     }
 
     /**

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/metadata/PropertyStore.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/metadata/PropertyStore.java
@@ -97,14 +97,20 @@ public class PropertyStore {
         return Property.fromProtobuf(resp.getProperty());
     }
 
-    public List<Property> list(String group, String name) throws BanyanDBException {
+    public List<Property> list(String group, String name, List<String> ids, List<String> tags) throws BanyanDBException {
+        BanyandbProperty.ListRequest.Builder builder = BanyandbProperty.ListRequest.newBuilder()
+                .setContainer(BanyandbCommon.Metadata.newBuilder()
+                .setGroup(group)
+                .setName(name)
+                .build());
+        if (ids != null && ids.size() > 0) {
+            builder.addAllIds(ids);
+        }
+        if (tags != null && tags.size() > 0) {
+            builder.addAllTags(tags);
+        }
         BanyandbProperty.ListResponse resp = HandleExceptionsWith.callAndTranslateApiException(() ->
-                this.stub.list(BanyandbProperty.ListRequest.newBuilder()
-                        .setContainer(BanyandbCommon.Metadata.newBuilder()
-                                .setGroup(group)
-                                .setName(name)
-                                .build())
-                        .build()));
+                this.stub.list(builder.build()));
 
         return resp.getPropertyList().stream().map(Property::fromProtobuf).collect(Collectors.toList());
     }

--- a/src/test/java/org/apache/skywalking/banyandb/v1/client/ITBanyanDBPropertyTests.java
+++ b/src/test/java/org/apache/skywalking/banyandb/v1/client/ITBanyanDBPropertyTests.java
@@ -28,6 +28,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
@@ -100,4 +102,30 @@ public class ITBanyanDBPropertyTests extends BanyanDBClientTestCI {
             Assert.assertEquals(property2, gotProperty);
         });
     }
+
+    @Test
+    public void test_PropertyList() throws BanyanDBException {
+        Property property = Property.create("default", "sw", "id1")
+                .addTag(TagAndValue.newStringTag("name", "bar"))
+                .build();
+        Assert.assertTrue(this.client.apply(property).created());
+        property = Property.create("default", "sw", "id2")
+                .addTag(TagAndValue.newStringTag("name", "foo"))
+                .build();
+        Assert.assertTrue(this.client.apply(property).created());
+
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<Property> gotProperties = client.findProperties("default", "sw");
+            Assert.assertEquals(2, gotProperties.size());
+        });
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<Property> gotProperties = client.findProperties("default", "sw", Arrays.asList("id1", "id2"), null);
+            Assert.assertEquals(2, gotProperties.size());
+        });
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<Property> gotProperties = client.findProperties("default", "sw", Arrays.asList("id2"), null);
+            Assert.assertEquals(1, gotProperties.size());
+        });
+    }
+
 }

--- a/src/test/java/org/apache/skywalking/banyandb/v1/client/metadata/PropertyStoreTest.java
+++ b/src/test/java/org/apache/skywalking/banyandb/v1/client/metadata/PropertyStoreTest.java
@@ -121,7 +121,7 @@ public class PropertyStoreTest extends AbstractBanyanDBClientTest {
                 .addTag(TagAndValue.newStringTag("name", "hello"))
                 .build();
         Assert.assertTrue(this.store.apply(property, PropertyStore.Strategy.REPLACE).created());
-        List<Property> listProperties = this.store.list("default", "sw");
+        List<Property> listProperties = this.store.list("default", "sw", null, null);
         Assert.assertNotNull(listProperties);
         Assert.assertEquals(1, listProperties.size());
         Assert.assertEquals(listProperties.get(0), property);


### PR DESCRIPTION
This update introduces two filters in the property client that enable property selection based on multiple IDs and tags. The server fully supports these filters.

It is related to https://github.com/apache/skywalking/issues/10559.