### PR TITLE
Support JDK21 build and fix wrong queue size

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,13 +55,13 @@ jobs:
         uses: apache/skywalking-eyes/dependency@20da317d1ad158e79e24355fdc28f53370e94c8a
 
   build:
-    name: JDK ${{ matrix.java-version }}
+    name: JDK ${{ matrix.version }} Build and Test
     needs: [ check-license-header ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
-        version: [ 8, 11, 17 ]
+        version: [ 8, 11, 17, 21 ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@ Changes by Version
 ==================
 Release Notes.
 
+0.6.0
+------------------
+
+### Features
+
+* Support JDK21 build. Upgrade lombok version to 1.18.30.
+
+### Bugs
+
+* Fix the number of channel and the channel size in the BulkWriteProcessor.
+
+
 0.5.0
 ------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <checkstyle.version>6.18</checkstyle.version>
         <junit.version>4.13.2</junit.version>
         <mockito-core.version>4.8.0</mockito-core.version>
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
 
         <!-- core lib dependency -->
         <bytebuddy.version>1.10.19</bytebuddy.version>

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/BulkWriteProcessor.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/BulkWriteProcessor.java
@@ -47,7 +47,7 @@ public abstract class BulkWriteProcessor implements Closeable {
      */
     protected BulkWriteProcessor(String processorName, int maxBulkSize, int flushInterval, int concurrency) {
         this.flushInterval = flushInterval;
-        this.buffer = new DataCarrier(processorName, maxBulkSize, concurrency);
+        this.buffer = new DataCarrier(processorName, concurrency, maxBulkSize);
         Properties properties = new Properties();
         properties.put("maxBulkSize", maxBulkSize);
         properties.put("flushInterval", flushInterval);


### PR DESCRIPTION
* Support JDK21 build. Upgrade lombok version to 1.18.30.
* Fix the number of channel and the channel size in the BulkWriteProcessor.