### PR TITLE
Remove analyze DNS name to get/refresh IP for create connection.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@ Changes by Version
 ==================
 Release Notes.
 
+0.7.0-rc4
+------------------
+
+### Features
+
+* Remove analyze DNS name to get/refresh IP for create connection.
+
 0.7.0-rc3
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ BanyanDBClient client = new BanyanDBClient("banyandb.svc:17912", "10.0.12.9:1791
 client.connect();
 ```
 
-These addresses are either IP addresses or DNS names. If DNS names are used, the client will resolve the DNS name to
-IP addresses and use them to connect to the server. The client will periodically refresh the IP addresses of the DNS
-name. The refresh interval can be configured by `resolveDNSInterval` option.
+These addresses are either IP addresses or DNS names. 
 
 The client will try to connect to the server in a round-robin manner. The client will periodically refresh the server
 addresses. The refresh interval can be configured by `refreshInterval` option.
@@ -43,8 +41,6 @@ options are listed below,
 | forceReconnectionThreshold | Threshold of force gRPC reconnection if network issue is encountered | 1                        |
 | forceTLS                   | Force use TLS for gRPC                                               | false                    |
 | sslTrustCAPath             | SSL: Trusted CA Path                                                 |                          |
-| sslCertChainPath           | SSL: Cert Chain Path                                                 |                          |
-| sslKeyPath                 | SSL: Cert Key Path                                                   |                          |
 
 ## Schema Management
 

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/Options.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/Options.java
@@ -45,10 +45,7 @@ public class Options {
      * Threshold of force gRPC reconnection if network issue is encountered
      */
     private long forceReconnectionThreshold = 1;
-    /**
-     * Threshold of resolving the DNS
-     */
-    private long resolveDNSInterval = 30 * 60;
+
     /**
      * Force use TLS for gRPC
      * Default is false
@@ -59,11 +56,11 @@ public class Options {
      */
     private String sslTrustCAPath = "";
     /**
-     * SSL: Cert Chain Path
+     * SSL: Cert Chain Path, BanyanDB server not support mTLS yet
      */
     private String sslCertChainPath = "";
     /**
-     * SSL: Cert Key Path
+     * SSL: Cert Key Path, BanyanDB server not support mTLS yet
      */
     private String sslKeyPath = "";
 

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/grpc/channel/DefaultChannelFactory.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/grpc/channel/DefaultChannelFactory.java
@@ -25,39 +25,27 @@ import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.SocketUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.skywalking.banyandb.v1.client.Options;
 import org.apache.skywalking.banyandb.v1.client.util.PrivateKeyUtil;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
 public class DefaultChannelFactory implements ChannelFactory {
     private final URI[] targets;
     private final Options options;
-    private SocketAddress[] addresses;
-    private long lastTargetsResolvedTime;
 
     @Override
     public ManagedChannel create() throws IOException {
-        if (this.addresses == null ||
-                System.currentTimeMillis() - this.lastTargetsResolvedTime > this.options.getResolveDNSInterval()) {
-            resolveTargets();
-        }
         NettyChannelBuilder managedChannelBuilder = NettyChannelBuilder.forAddress(resolveAddress())
                 .maxInboundMessageSize(options.getMaxInboundMessageSize())
                 .usePlaintext();
@@ -91,30 +79,12 @@ public class DefaultChannelFactory implements ChannelFactory {
         return managedChannelBuilder.build();
     }
 
-    private void resolveTargets() {
-        this.addresses = Arrays.stream(this.targets)
-                .flatMap(target -> {
-                    try {
-                        return Arrays.stream(SocketUtils.allAddressesByName(target.getHost()))
-                                .map(InetAddress::getHostAddress)
-                                .map(ip -> new InetSocketAddress(ip, target.getPort()));
-                    } catch (Throwable t) {
-                        log.error("Failed to resolve the BanyanDB server's address ", t);
-                    }
-                    return Stream.empty();
-                })
-                .sorted(Comparator.comparing(InetSocketAddress::toString))
-                .distinct()
-                .toArray(InetSocketAddress[]::new);
-        this.lastTargetsResolvedTime = System.currentTimeMillis();
-    }
-
     private SocketAddress resolveAddress() throws UnknownHostException {
-        int numAddresses = this.addresses.length;
+        int numAddresses = this.targets.length;
         if (numAddresses < 1) {
             throw new UnknownHostException();
         }
         int offset = numAddresses == 1 ? 0 : PlatformDependent.threadLocalRandom().nextInt(numAddresses);
-        return this.addresses[offset];
+        return new InetSocketAddress(this.targets[offset].getHost(), this.targets[offset].getPort());
     }
 }


### PR DESCRIPTION
When the DNS's IP is dynamic, it's hard to build a TLS connection. So if the target is a DNS name, use it directly rather than
translate to IP.