### PR TITLE
Added reloadable ssl config for BanyanDB Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <netty.tcnative.version>2.0.65.Final</netty.tcnative.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <auto-value.version>1.10.4</auto-value.version>
+        <ayza.version>10.0.2</ayza.version>
         <testcontainers.version>1.19.7</testcontainers.version>
         <awaitility.version>4.2.1</awaitility.version>
         <bufbuild.protoc-gen-validate.version>1.2.1</bufbuild.protoc-gen-validate.version>
@@ -174,6 +175,12 @@
             <artifactId>auto-value-annotations</artifactId>
             <version>${auto-value.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.hakky54</groupId>
+            <artifactId>ayza-for-pem</artifactId>
+            <version>${ayza.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/grpc/channel/DefaultChannelFactory.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/grpc/channel/DefaultChannelFactory.java
@@ -70,7 +70,7 @@ public class DefaultChannelFactory implements ChannelFactory {
             if (isCAFileExist) {
                 BasicFileAttributes caFileAttributes = Files.readAttributes(caFile, BasicFileAttributes.class);
                 lastModifiedTimeCaFile = ZonedDateTime.ofInstant(caFileAttributes.lastModifiedTime().toInstant(), ZoneOffset.UTC);
-                X509ExtendedTrustManager trustManager = TrustManagerUtils.createTrustManager(PemUtils.loadCertificate(caFile));
+                X509ExtendedTrustManager trustManager = PemUtils.loadTrustMaterial(caFile);
                 swappableTrustManager = TrustManagerUtils.createSwappableTrustManager(trustManager);
                 builder.trustManager(swappableTrustManager);
 
@@ -99,7 +99,7 @@ public class DefaultChannelFactory implements ChannelFactory {
                 Path caFile = Paths.get(options.getSslTrustCAPath());
                 BasicFileAttributes latestCaFileAttributes = Files.readAttributes(caFile, BasicFileAttributes.class);
                 if (ZonedDateTime.ofInstant(latestCaFileAttributes.lastModifiedTime().toInstant(), ZoneOffset.UTC).isAfter(lastModifiedTimeCaFile)) {
-                    X509ExtendedTrustManager trustManager = TrustManagerUtils.createTrustManager(PemUtils.loadCertificate(caFile));
+                    X509ExtendedTrustManager trustManager = PemUtils.loadTrustMaterial(caFile);
                     TrustManagerUtils.swapTrustManager(swappableTrustManager, trustManager);
                     log.info("SSL configuration has been refreshed");
                 }

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/grpc/channel/DefaultChannelFactory.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/grpc/channel/DefaultChannelFactory.java
@@ -101,7 +101,7 @@ public class DefaultChannelFactory implements ChannelFactory {
                 if (ZonedDateTime.ofInstant(latestCaFileAttributes.lastModifiedTime().toInstant(), ZoneOffset.UTC).isAfter(lastModifiedTimeCaFile)) {
                     X509ExtendedTrustManager trustManager = PemUtils.loadTrustMaterial(caFile);
                     TrustManagerUtils.swapTrustManager(swappableTrustManager, trustManager);
-                    log.info("SSL configuration has been refreshed");
+                    log.info("SSL configuration has been reloaded");
                 }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/src/main/java/org/apache/skywalking/banyandb/v1/client/grpc/channel/DefaultChannelFactory.java
+++ b/src/main/java/org/apache/skywalking/banyandb/v1/client/grpc/channel/DefaultChannelFactory.java
@@ -97,10 +97,11 @@ public class DefaultChannelFactory implements ChannelFactory {
         return () -> {
             try {
                 Path caFile = Paths.get(options.getSslTrustCAPath());
-                BasicFileAttributes latestCaFileAttributes = Files.readAttributes(caFile, BasicFileAttributes.class);
-                if (ZonedDateTime.ofInstant(latestCaFileAttributes.lastModifiedTime().toInstant(), ZoneOffset.UTC).isAfter(lastModifiedTimeCaFile)) {
+                BasicFileAttributes caFileAttributes = Files.readAttributes(caFile, BasicFileAttributes.class);
+                if (ZonedDateTime.ofInstant(caFileAttributes.lastModifiedTime().toInstant(), ZoneOffset.UTC).isAfter(lastModifiedTimeCaFile)) {
                     X509ExtendedTrustManager trustManager = PemUtils.loadTrustMaterial(caFile);
                     TrustManagerUtils.swapTrustManager(swappableTrustManager, trustManager);
+                    lastModifiedTimeCaFile = ZonedDateTime.ofInstant(caFileAttributes.lastModifiedTime().toInstant(), ZoneOffset.UTC);
                     log.info("SSL configuration has been reloaded");
                 }
             } catch (IOException e) {


### PR DESCRIPTION
This PR is an implementation for the following feature request: https://github.com/apache/skywalking/issues/12863
Where the OP requests to have a reloadable ssl configuration without the need of restart/recreate the client. The current implementation checks every hour whether the file has been adjusted, if it has been updated it takes the file and reloads the existing ssl configuration in the client